### PR TITLE
Add initial 2D tiling support

### DIFF
--- a/src/3dtiles/Tileset.mjs
+++ b/src/3dtiles/Tileset.mjs
@@ -1,4 +1,3 @@
-import Batched3DModel from './Batched3DModel.mjs'
 import fsExtra from 'fs-extra'
 import path from 'path'
 
@@ -28,7 +27,7 @@ class Tileset {
         },
         geometricError: 0.0,
         content: {
-          url: tileName
+          url: "./" + tileName
         }
       }
     }

--- a/src/citygml/CityObject.mjs
+++ b/src/citygml/CityObject.mjs
@@ -20,6 +20,10 @@ class CityObject {
     return new Envelope(envelopeNode)
   }
 
+  getCenter() {
+    return this.getEnvelope().getBoundingBox().getCenter()
+  }
+
   /**
    * @returns {TriangleMesh}
    */

--- a/src/citygml/CityObject/Building.mjs
+++ b/src/citygml/CityObject/Building.mjs
@@ -1,6 +1,7 @@
 import LinearRing from '../../geometry/LinearRing.mjs'
 import TriangleMesh from '../../geometry/TriangleMesh.mjs'
 import CityObject from '../CityObject.mjs'
+import Envelope from "../Envelope.mjs";
 
 class Building extends CityObject {
 
@@ -35,6 +36,17 @@ class Building extends CityObject {
         .filter(ring => !!ring)
     }
     return this.rings
+  }
+
+  /**
+   * @returns {Envelope|Null}
+   */
+  getEnvelope () {
+    let envelopeNode = this.cityNode.findCityNode('./gml:boundedBy/gml:Envelope')
+    if (!envelopeNode) {
+      return null
+    }
+    return new Envelope(envelopeNode)
   }
 
   /**

--- a/src/geometry/BoundingBox.mjs
+++ b/src/geometry/BoundingBox.mjs
@@ -20,6 +20,17 @@ class BoundingBox {
   /**
    * @returns {Cesium.Cartographic}
    */
+  getCenter() {
+    return new Cesium.Cartographic(
+      this.min.longitude + (this.max.longitude - this.min.longitude) / 2,
+      this.min.latitude + (this.max.latitude - this.min.latitude) / 2,
+      this.min.height + (this.max.height - this.min.height) / 2,
+    )
+  }
+
+  /**
+   * @returns {Cesium.Cartographic}
+   */
   getMin () {
     return this.min
   }
@@ -29,6 +40,16 @@ class BoundingBox {
    */
   getMax () {
     return this.max
+  }
+
+  /**
+   * @param {Cesium.Cartographic} c
+   * @return {boolean}
+   */
+  contains(c) {
+    return c.latitude >= this.min.latitude && c.latitude < this.max.latitude &&
+           c.longitude >= this.min.longitude && c.longitude < this.max.longitude &&
+           c.height >= this.min.height && c.height < this.max.height;
   }
 
   /**


### PR DESCRIPTION
This patch adds a very basic form of tiling support by allowing users to specify a number of tiles per side (a rectangle) and then generating `n` by `n` tiles, ignoring the height dimension. This allows larger GML files to be split into multiple b3dm files which can be loaded individually. Each tile effectively acts as its own 3D tileset. To produce one big tileset, a new `tileset.json` file is created, which references all other tiles by providing URIs.

Note that this patch does not introduce LODs.
