### PR TITLE
Add "snap-to-ground" option

### DIFF
--- a/src/Converter.mjs
+++ b/src/Converter.mjs
@@ -18,7 +18,10 @@ class Converter {
     this.options = Object.assign({
       propertiesGetter: null,
       objectFilter: null,
-      srsProjections: {}
+      srsProjections: {},
+      coordinateTransform: {
+        snapToGround: false,
+      }
     }, options)
   }
 
@@ -33,7 +36,7 @@ class Converter {
     let cityObjects = [], boundingBoxes = []
     inputPaths.forEach((inputPath, i) => {
       console.debug(`Reading CityGML file ${i + 1}/${inputPaths.length}...`)
-      let cityDocument = CityDocument.fromFile(inputPath, srsTranslator)
+      let cityDocument = CityDocument.fromFile(inputPath, srsTranslator, this.options.coordinateTransform)
       let cityModel = cityDocument.getCityModel()
       let objs = cityModel.getCityObjects()
       console.debug(` Found ${objs.length} city objects.`)

--- a/src/citygml/CityNode.mjs
+++ b/src/citygml/CityNode.mjs
@@ -125,7 +125,7 @@ class CityNode {
   /**
    * @returns {Cesium.Cartographic[]}
    */
-  getTextAsCoordinatesCartographic () {
+  getTextAsCoordinatesCartographic (offset = 0) {
     let srs = this.getSRS()
     let srsTranslator = this.document.getSRSTranslator()
 
@@ -140,7 +140,7 @@ class CityNode {
       point = point.map(p => parseFloat(p))
       point = point.map(p => isNaN(p) ? 0 : p)
       point = srsTranslator.forward(point, srs, 'WGS84')
-      point = Cesium.Cartographic.fromDegrees(point[0], point[1], point[2])
+      point = Cesium.Cartographic.fromDegrees(point[0], point[1], point[2] + offset)
       points.push(point)
     }
     return points
@@ -149,8 +149,8 @@ class CityNode {
   /**
    * @returns {Cesium.Cartesian3[]}
    */
-  getTextAsCoordinatesCartesian () {
-    return this.getTextAsCoordinatesCartographic().map((point) => {
+  getTextAsCoordinatesCartesian (offset = 0) {
+    return this.getTextAsCoordinatesCartographic(offset).map((point) => {
       return Cesium.Cartographic.toCartesian(point)
     })
   }
@@ -158,8 +158,8 @@ class CityNode {
   /**
    * @returns {Cesium.Cartographic}
    */
-  getTextAsCoordinates1Cartographic () {
-    let coords = this.getTextAsCoordinatesCartographic()
+  getTextAsCoordinates1Cartographic (offset = 0) {
+    let coords = this.getTextAsCoordinatesCartographic(offset)
     if (coords.length !== 1) {
       throw new Error('Expected 1 coordinates, but found ' + coords.length)
     }
@@ -169,8 +169,8 @@ class CityNode {
   /**
    * @returns {Cesium.Cartesian3}
    */
-  getTextAsCoordinates1Cartesian () {
-    let point = this.getTextAsCoordinates1Cartographic()
+  getTextAsCoordinates1Cartesian (offset = 0) {
+    let point = this.getTextAsCoordinates1Cartographic(offset)
     return Cesium.Cartographic.toCartesian(point)
   }
 

--- a/src/citygml/CityObject/Building.mjs
+++ b/src/citygml/CityObject/Building.mjs
@@ -17,12 +17,17 @@ class Building extends CityObject {
    */
   getLinearRings () {
     if (!this.rings) {
+      let heightOffset = 0;
+      if (this.cityNode.document.getCoordinateTransformOptions().snapToGround) {
+        heightOffset = -this.getEnvelope().getBoundingBox().min.height;
+      }
+
       this.rings = this.cityNode.selectCityNodes('.//gml:Polygon//gml:LinearRing')
         .map(ringNode => {
           let pos = ringNode.selectCityNodes('./gml:pos')
-          let points = pos.map(n => n.getTextAsCoordinates1Cartesian())
+          let points = pos.map(n => n.getTextAsCoordinates1Cartesian(heightOffset))
           if (points.length === 0) {
-            points = ringNode.selectCityNode('./gml:posList').getTextAsCoordinatesCartesian()
+            points = ringNode.selectCityNode('./gml:posList').getTextAsCoordinatesCartesian(heightOffset)
           }
 
           if (points.length < 4) {

--- a/src/citygml/Document.mjs
+++ b/src/citygml/Document.mjs
@@ -9,10 +9,12 @@ class Document {
   /**
    * @param {Document} xmlDoc
    * @param {SRSTranslator} srsTranslator
+   * @param {{snapToGround: boolean}} coordinateTransformOptions
    */
-  constructor (xmlDoc, srsTranslator) {
+  constructor (xmlDoc, srsTranslator, coordinateTransformOptions) {
     this.xmlDoc = xmlDoc
     this.srsTranslator = srsTranslator
+    this.coordinateTransformOptions = coordinateTransformOptions
   }
 
   /**
@@ -20,6 +22,13 @@ class Document {
    */
   getSRSTranslator () {
     return this.srsTranslator
+  }
+
+  /**
+   * @return {{snapToGround: boolean}}
+   */
+  getCoordinateTransformOptions() {
+    return this.coordinateTransformOptions
   }
 
   /**
@@ -34,9 +43,10 @@ class Document {
   /**
    * @param {String} path
    * @param {SRSTranslator} [srsTranslator]
+   * @param {{snapToGround: boolean}} coordinateTransformOptions
    * @returns {Document}
    */
-  static fromFile (path, srsTranslator) {
+  static fromFile (path, srsTranslator, coordinateTransformOptions) {
     if (!srsTranslator) {
       srsTranslator = new SRSTranslator()
     }
@@ -47,7 +57,7 @@ class Document {
       },
     })
     let dom = domParser.parseFromString(data)
-    return new Document(dom, srsTranslator)
+    return new Document(dom, srsTranslator, coordinateTransformOptions)
   }
 
 }


### PR DESCRIPTION
This patch adds an option which allows the user to specify that all geometry is to be snapped to the ground (i.e. height `0`). This works by moving all coordinates down by the minimum height of position of the bounding box of the city object.

Note that this patch does not adjust the bounding box at all and only changes the positions of the vertices.