### PR TITLE
Add getter for the CityObject's ID node

### DIFF
--- a/src/citygml/CityObject.mjs
+++ b/src/citygml/CityObject.mjs
@@ -20,6 +20,9 @@ class CityObject {
     return new Envelope(envelopeNode)
   }
 
+  /**
+   * @returns {String} This object's ID ("gml:id")
+   */
   get id() {
     return this.cityNode.getAttribute('gml:id')
   }

--- a/src/citygml/CityObject.mjs
+++ b/src/citygml/CityObject.mjs
@@ -20,6 +20,10 @@ class CityObject {
     return new Envelope(envelopeNode)
   }
 
+  get id() {
+    return this.cityNode.getAttribute('gml:id')
+  }
+
   /**
    * @returns {TriangleMesh}
    */


### PR DESCRIPTION
This patch adds a convenience getter for the `gml:id` attribute of city objects.